### PR TITLE
bumped version of incremental to latest 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "repository": "git@github.com:tehsis/charata.git",
   "dependencies": {
-    "incremental-dom": "^0.1.0"
+    "incremental-dom": "^0.3.0"
   },
   "devDependencies": {
     "babel": "^5.8.20",


### PR DESCRIPTION
Found your library, it is beautifully simple.  Thanks for sharing it.  Noticed the incremental-dom is on 0.3.0 version now and your library was using 0.1.0.  I tested out 0.3.0 on my machine and it seems nothing is broken, so they are "kind" of following semver.  Except for that whole don't use 0 version business.
